### PR TITLE
fix: move index.html to root directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" href="/resources/style.css" />
+    <link rel="stylesheet" href="./resources/style.css" />
     <script src="https://kit.fontawesome.com/4c536a6bd5.js" crossorigin="anonymous"></script>
     <title>Etch-A-Sketch</title>
 </head>
@@ -45,7 +45,7 @@
         <a href="https://github.com/yskooo" target="_blank">
             <i class="fab fa-github"></i></a>
     </footer>
-    <script src="/resources/script.js"></script>
+    <script src="./resources/script.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
By default, GitHub Pages searches for an `index.html` file in the root directory to build the website. However, the `index.html` file in this project is in `resources` instead, which makes the build fail. I moved `index.html` to the root directory and the CSS and JavaScript should be correctly linked as well.